### PR TITLE
Avoid panicking on invalid cell references

### DIFF
--- a/src/extension/writer.rs
+++ b/src/extension/writer.rs
@@ -3,15 +3,16 @@
 use crate::database::column::Column;
 use crate::database::column::ColumnType;
 use crate::error::RustySheetError;
+use crate::spreadsheet::SpreadsheetError;
 use crate::spreadsheet::cell::Cell;
 use crate::spreadsheet::cell::CellType;
+use crate::spreadsheet::resolve_loaded_shared_string;
+use crate::spreadsheet::sheet::Sheet;
 use duckdb::core::FlatVector;
 use duckdb::core::Inserter;
 use libduckdb_sys::duckdb_date;
 use libduckdb_sys::duckdb_time;
 use libduckdb_sys::duckdb_timestamp;
-use crate::spreadsheet::sheet::Sheet;
-use crate::spreadsheet::SpreadsheetError;
 
 /// Writes a cell value to a DuckDB vector based on column type.
 /// Handles type conversion and error mapping for different data types.
@@ -25,8 +26,9 @@ pub(super) fn write_to_vector(sheet: &Sheet, column: &Column, cell: &Cell, vecto
         )
     };
     let cell = if cell.kind == CellType::SharedString {
-        let index = cell.value.parse::<usize>()?;
-        if let Some(shared_string) = &shared_strings[index] {
+        if let Some(shared_string) =
+            resolve_loaded_shared_string(shared_strings, &sheet.file_name, &sheet.name, cell)?
+        {
             &Cell {
                 row: cell.row,
                 col: cell.col,

--- a/src/spreadsheet/mod.rs
+++ b/src/spreadsheet/mod.rs
@@ -46,6 +46,29 @@ pub(crate) fn resolve_number_format(
     })
 }
 
+#[cfg(test)]
+mod number_format_tests {
+    use super::*;
+
+    #[test]
+    fn invalid_style_with_out_of_range_column_returns_error() {
+        let error = resolve_number_format(
+            &[CellType::Number],
+            "workbook.xlsb",
+            "Sheet1",
+            10,
+            16_384,
+            999,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Cell '[workbook.xlsb]Sheet1!R11C16385': invalid style index 999; workbook defines 1 styles"
+        );
+    }
+}
+
 pub(crate) fn resolve_shared_string<'a>(
     shared_strings: &'a [String],
     mappings: &HashMap<usize, usize>,
@@ -127,6 +150,10 @@ pub(crate) enum SpreadsheetError {
     /// Error indicating a shared string index is outside the workbook's shared string table.
     #[error("Cell '[{0}]{1}!{2}': invalid shared string index {3}")]
     CellSharedStringIndexError(String, String, String, usize),
+
+    /// Error indicating a worksheet cell reference is outside the supported spreadsheet bounds.
+    #[error("Sheet '[{0}]{1}': invalid cell reference '{2}'")]
+    CellReferenceError(String, String, String),
 }
 
 pub(crate) trait Spreadsheet {

--- a/src/spreadsheet/mod.rs
+++ b/src/spreadsheet/mod.rs
@@ -27,6 +27,25 @@ pub(crate) mod xlsx;
 pub(crate) mod criteria;
 pub(crate) mod sheet;
 
+pub(crate) fn resolve_number_format(
+    number_formats: &[CellType],
+    file_name: &str,
+    sheet_name: &str,
+    row: usize,
+    col: usize,
+    style_index: usize,
+) -> Result<CellType, SpreadsheetError> {
+    number_formats.get(style_index).copied().ok_or_else(|| {
+        SpreadsheetError::CellStyleIndexError(
+            file_name.to_owned(),
+            sheet_name.to_owned(),
+            crate::spreadsheet::reference::index_to_reference(row, col),
+            style_index,
+            number_formats.len(),
+        )
+    })
+}
+
 #[derive(Error, Debug)]
 pub(crate) enum SpreadsheetError {
     /// Error indicating the spreadsheet format is not supported
@@ -48,6 +67,10 @@ pub(crate) enum SpreadsheetError {
     /// Error indicating a specific cell value is invalid
     #[error("Cell '[{0}]{1}!{2}': {3}")]
     CellValueError(String, String, String, String),
+
+    /// Error indicating a cell style index is outside the workbook's style table.
+    #[error("Cell '[{0}]{1}!{2}': invalid style index {3}; workbook defines {4} styles")]
+    CellStyleIndexError(String, String, String, usize, usize),
 }
 
 pub(crate) trait Spreadsheet {

--- a/src/spreadsheet/mod.rs
+++ b/src/spreadsheet/mod.rs
@@ -46,6 +46,58 @@ pub(crate) fn resolve_number_format(
     })
 }
 
+pub(crate) fn resolve_shared_string<'a>(
+    shared_strings: &'a [String],
+    mappings: &HashMap<usize, usize>,
+    file_name: &str,
+    sheet_name: &str,
+    cell: &Cell,
+) -> Result<&'a str, RustySheetError> {
+    let shared_string_index = cell.value.parse::<usize>()?;
+    let mapped_index = mappings.get(&shared_string_index).copied().ok_or_else(|| {
+        SpreadsheetError::CellSharedStringIndexError(
+            file_name.to_owned(),
+            sheet_name.to_owned(),
+            cell.reference(),
+            shared_string_index,
+        )
+    })?;
+
+    shared_strings
+        .get(mapped_index)
+        .map(String::as_str)
+        .ok_or_else(|| {
+            SpreadsheetError::CellSharedStringIndexError(
+                file_name.to_owned(),
+                sheet_name.to_owned(),
+                cell.reference(),
+                shared_string_index,
+            )
+            .into()
+        })
+}
+
+pub(crate) fn resolve_loaded_shared_string<'a>(
+    shared_strings: &'a [Option<String>],
+    file_name: &str,
+    sheet_name: &str,
+    cell: &Cell,
+) -> Result<Option<&'a str>, RustySheetError> {
+    let shared_string_index = cell.value.parse::<usize>()?;
+    shared_strings
+        .get(shared_string_index)
+        .map(Option::as_deref)
+        .ok_or_else(|| {
+            SpreadsheetError::CellSharedStringIndexError(
+                file_name.to_owned(),
+                sheet_name.to_owned(),
+                cell.reference(),
+                shared_string_index,
+            )
+            .into()
+        })
+}
+
 #[derive(Error, Debug)]
 pub(crate) enum SpreadsheetError {
     /// Error indicating the spreadsheet format is not supported
@@ -71,6 +123,10 @@ pub(crate) enum SpreadsheetError {
     /// Error indicating a cell style index is outside the workbook's style table.
     #[error("Cell '[{0}]{1}!{2}': invalid style index {3}; workbook defines {4} styles")]
     CellStyleIndexError(String, String, String, usize, usize),
+
+    /// Error indicating a shared string index is outside the workbook's shared string table.
+    #[error("Cell '[{0}]{1}!{2}': invalid shared string index {3}")]
+    CellSharedStringIndexError(String, String, String, usize),
 }
 
 pub(crate) trait Spreadsheet {
@@ -132,56 +188,71 @@ pub(crate) trait Spreadsheet {
         let (shared_strings, mappings) = self.load_shared_strings(Some(shared_indexes))?;
 
         let mut tables = Vec::<Table>::new();
-        for (name, header, data, row_lower_bound, col_lower_bound, col_upper_bound) in sheets.into_iter() {
-            let names = (col_lower_bound..=col_upper_bound).map(|col| {
-                let index = col - col_lower_bound;
-                if let Some(cell) = &header[index] {
-                    let value = if cell.kind == CellType::SharedString {
-                        let id = cell.value.parse::<usize>().expect("Shared string index");
-                        let index = mappings[&id];
-                        shared_strings[index].to_owned()
-                    } else {
-                        cell.to_string()
-                    };
-                    if !criteria.nulls.contains(&value) {
-                        value
-                    } else {
-                        index_to_col(col).to_owned()
-                    }
-                } else {
-                    index_to_col(col).to_owned()
-                }
-            }).collect::<Vec<_>>();
-
-            let columns = names.iter().zip(data)
-                .map(|(name, cells)| {
-                    let types = cells.iter()
-                        .map(|cell| {
-                            if cell.kind == CellType::SharedString {
-                                let id = cell.value.parse::<usize>().expect("Shared string index");
-                                let index = mappings[&id];
-                                let value = shared_strings[index].as_str();
-                                ColumnType::from(if criteria.nulls.contains(value) {
-                                    &CellType::Empty
-                                } else {
-                                    &cell.kind
-                                }, value)
-                            } else {
-                                ColumnType::from(&cell.kind, &cell.value)
-                            }
+        let file_name = self.name();
+        for (sheet_name, header, data, row_lower_bound, col_lower_bound, col_upper_bound) in sheets.into_iter() {
+            let names = (col_lower_bound..=col_upper_bound)
+                .map(|col| -> Result<String, RustySheetError> {
+                    let index = col - col_lower_bound;
+                    if let Some(cell) = &header[index] {
+                        let value = if cell.kind == CellType::SharedString {
+                            resolve_shared_string(
+                                &shared_strings,
+                                &mappings,
+                                &file_name,
+                                &sheet_name,
+                                cell,
+                            )?.to_owned()
+                        } else {
+                            cell.to_string()
+                        };
+                        Ok(if !criteria.nulls.contains(&value) {
+                            value
+                        } else {
+                            index_to_col(col).to_owned()
                         })
-                        .collect::<Vec<_>>();
-                    Column {
-                        name: name.to_owned(),
-                        kind: presets.iter()
-                            .find(|(pattern, _)| pattern.matches(name))
-                            .map(|(_, kind)| kind.to_owned())
-                            .unwrap_or(ColumnType::detect(types)),
+                    } else {
+                        Ok(index_to_col(col).to_owned())
                     }
                 })
-                .collect::<Vec<_>>();
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let columns = names.iter().zip(data)
+                .map(|(column_name, cells)| -> Result<Column, RustySheetError> {
+                    let types = cells.iter()
+                        .map(|cell| -> Result<Option<ColumnType>, RustySheetError> {
+                            if cell.kind == CellType::SharedString {
+                                let value = resolve_shared_string(
+                                    &shared_strings,
+                                    &mappings,
+                                    &file_name,
+                                    &sheet_name,
+                                    cell,
+                                )?;
+                                Ok(ColumnType::from(
+                                    if criteria.nulls.contains(value) {
+                                        &CellType::Empty
+                                    } else {
+                                        &cell.kind
+                                    },
+                                    value,
+                                ))
+                            } else {
+                                Ok(ColumnType::from(&cell.kind, &cell.value))
+                            }
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    Ok(Column {
+                        name: column_name.to_owned(),
+                        kind: presets
+                            .iter()
+                            .find(|(pattern, _)| pattern.matches(column_name))
+                            .map(|(_, kind)| kind.to_owned())
+                            .unwrap_or(ColumnType::detect(types)),
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
             tables.push(Table {
-                name,
+                name: sheet_name,
                 columns,
                 row_lower_bound,
                 col_lower_bound,

--- a/src/spreadsheet/reference.rs
+++ b/src/spreadsheet/reference.rs
@@ -1,3 +1,6 @@
+const MAX_COL_INDEX: usize = 16_383;
+const MAX_ROW_NUMBER: usize = 1_048_576;
+
 /// Converts a zero-based column index to Excel column letter notation
 ///
 /// Uses a precomputed lookup table for optimal performance. Supports
@@ -44,40 +47,12 @@ pub(crate) fn col_to_index(letters: &str) -> Option<usize> {
     let mut column = 0usize;
     for char in letters.chars() {
         if 'A' <= char && char <= 'Z' {
-            column = column * 26 + char as usize - 64;
+            column = column.checked_mul(26)?.checked_add(char as usize - 64)?;
         } else {
             break;
         }
     }
-    if column > 0 {
-        Some(column - 1)
-    } else {
-        None
-    }
-}
-
-/// Converts a zero-based row index to Excel row number string
-///
-/// Transforms internal zero-based row indexing into Excel's 1-based row numbering system.
-/// This conversion bridges the gap between internal storage (0-based) and Excel's
-/// user-facing representation (1-based).
-///
-/// The conversion is straightforward: adds 1 to the zero-based index and converts
-/// the result to a string. This maintains compatibility with Excel's row numbering
-/// convention while using efficient zero-based indexing internally.
-///
-/// # Arguments
-/// * `index` - Zero-based row index (0 = row 1, 1 = row 2, etc.)
-///
-/// # Returns
-/// Excel-style row number as a string (1-based)
-///
-/// # Examples
-/// - 0 -> "1"      // First row
-/// - 1 -> "2"      // Second row
-/// - 99 -> "100"   // 100th row
-pub(crate) fn index_to_row(index: usize) -> String {
-    (index + 1).to_string()
+    zero_based_column(column)
 }
 
 /// Converts an Excel row number string to a zero-based row index
@@ -89,22 +64,25 @@ pub(crate) fn index_to_row(index: usize) -> String {
 /// `Some(usize)` containing the zero-based row index if valid,
 /// `None` if the input cannot be parsed as a valid row number
 pub(crate) fn row_to_index(row: &str) -> Option<usize> {
-    row.parse::<usize>().ok().map(|row| row - 1)
+    row.parse::<usize>().ok().and_then(zero_based_row)
 }
 
-/// Converts zero-based row and column indices to an Excel-style cell reference
+/// Converts zero-based row and column indices to a cell reference
 ///
 /// # Arguments
 /// * `row_index` - Zero-based row index (0 = row 1)
 /// * `col_index` - Zero-based column index (0 = column "A")
 ///
 /// # Returns
-/// Excel-style cell reference as a string (e.g., "A1", "B2", "AB100")
+/// A1 notation for valid Excel coordinates, or R1C1 notation for out-of-range
+/// coordinates so malformed-file error reporting remains panic-free.
 pub(crate) fn index_to_reference(row_index: usize, col_index: usize) -> String {
-    let mut reference = String::new();
-    reference.push_str(index_to_col(col_index));
-    reference.push_str(&index_to_row(row_index));
-    reference
+    let row_number = row_index.saturating_add(1);
+    if let Some(column) = INDEXES_TO_COLUMNS.get(col_index) {
+        format!("{column}{row_number}")
+    } else {
+        format!("R{row_number}C{}", col_index.saturating_add(1))
+    }
 }
 
 /// Converts an Excel-style cell reference to zero-based row and column indices
@@ -135,17 +113,32 @@ pub(crate) fn index_to_reference(row_index: usize, col_index: usize) -> String {
 pub(crate) fn reference_to_index(letters: &str) -> Option<(usize, usize)> {
     let mut column = 0usize;
     let mut row = 0usize;
+    let mut row_started = false;
     for char in letters.chars() {
-        if 'A' <= char && char <= 'Z' {
-            column = column * 26 + char as usize - 64;
+        if 'A' <= char && char <= 'Z' && !row_started {
+            column = column.checked_mul(26)?.checked_add(char as usize - 64)?;
         } else if '0' <= char && char <= '9' {
-            row = row * 10 + char as usize - 48;
+            row_started = true;
+            row = row.checked_mul(10)?.checked_add(char as usize - 48)?;
         } else {
-            break;
+            return None;
         }
     }
-    if column > 0 {
-        Some((row - 1, column - 1))
+    Some((zero_based_row(row)?, zero_based_column(column)?))
+}
+
+fn zero_based_column(column: usize) -> Option<usize> {
+    let index = column.checked_sub(1)?;
+    if index <= MAX_COL_INDEX {
+        Some(index)
+    } else {
+        None
+    }
+}
+
+fn zero_based_row(row: usize) -> Option<usize> {
+    if (1..=MAX_ROW_NUMBER).contains(&row) {
+        Some(row - 1)
     } else {
         None
     }
@@ -1419,3 +1412,25 @@ const INDEXES_TO_COLUMNS: [&'static str; 16384] = [
     "XEF", "XEG", "XEH", "XEI", "XEJ", "XEK", "XEL", "XEM", "XEN", "XEO", "XEP", "XEQ", "XER",
     "XES", "XET", "XEU", "XEV", "XEW", "XEX", "XEY", "XEZ", "XFA", "XFB", "XFC", "XFD",
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_reference_bounds() {
+        assert_eq!(col_to_index("XFD"), Some(16_383));
+        assert_eq!(row_to_index("1048576"), Some(1_048_575));
+        assert_eq!(reference_to_index("XFD1048576"), Some((1_048_575, 16_383)));
+    }
+
+    #[test]
+    fn rejects_out_of_bounds_references() {
+        assert_eq!(col_to_index("XFE"), None);
+        assert_eq!(row_to_index("0"), None);
+        assert_eq!(row_to_index("1048577"), None);
+        assert_eq!(reference_to_index("A0"), None);
+        assert_eq!(reference_to_index("XFE1"), None);
+        assert_eq!(reference_to_index("A1048577"), None);
+    }
+}

--- a/src/spreadsheet/xls.rs
+++ b/src/spreadsheet/xls.rs
@@ -10,6 +10,7 @@ use crate::spreadsheet::cell::CellType;
 use crate::spreadsheet::criteria::Criteria;
 use crate::spreadsheet::excel::load_number_formats;
 use crate::spreadsheet::reference::index_to_reference;
+use crate::spreadsheet::resolve_number_format;
 use crate::spreadsheet::sheet::Sheet;
 use crate::spreadsheet::Spreadsheet;
 use crate::spreadsheet::SpreadsheetError;
@@ -201,7 +202,14 @@ impl Spreadsheet for XlsSpreadsheet {
                                 }
                                 last_row = Some(row);
                                 let index = self.reader.read_u16()? as usize;
-                                let kind = self.number_formats[index];
+                                let kind = resolve_number_format(
+                                    &self.number_formats,
+                                    &sheet.file_name,
+                                    &sheet.name,
+                                    row,
+                                    col,
+                                    index,
+                                )?;
                                 let value = self.reader.read_rk_number()?;
                                 sheet.push(Cell {
                                     row,
@@ -234,7 +242,14 @@ impl Spreadsheet for XlsSpreadsheet {
                             };
                             let kind = match either {
                                 Either::Left(kind) => kind,
-                                Either::Right(index) => self.number_formats[index],
+                                Either::Right(index) => resolve_number_format(
+                                    &self.number_formats,
+                                    &sheet.file_name,
+                                    &sheet.name,
+                                    row,
+                                    col,
+                                    index,
+                                )?,
                             };
                             if kind != CellType::Error {
                                 if !criteria.nulls.contains(&value) {

--- a/src/spreadsheet/xlsb.rs
+++ b/src/spreadsheet/xlsb.rs
@@ -10,6 +10,7 @@ use crate::spreadsheet::criteria::Criteria;
 use crate::spreadsheet::excel;
 use crate::spreadsheet::excel::load_relationships;
 use crate::spreadsheet::reference::index_to_reference;
+use crate::spreadsheet::resolve_number_format;
 use crate::spreadsheet::sheet::Sheet;
 use crate::spreadsheet::Spreadsheet;
 use crate::spreadsheet::SpreadsheetError;
@@ -221,7 +222,14 @@ impl Spreadsheet for XlsbSpreadsheet {
                             };
                             let kind = match either {
                                 Either::Left(kind) => kind,
-                                Either::Right(index) => (self.number_formats)[index],
+                                Either::Right(index) => resolve_number_format(
+                                    &self.number_formats,
+                                    &sheet.file_name,
+                                    &sheet.name,
+                                    row,
+                                    col,
+                                    index,
+                                )?,
                             };
                             if kind != CellType::Error {
                                 if !criteria.nulls.contains(&value) {

--- a/src/spreadsheet/xlsx.rs
+++ b/src/spreadsheet/xlsx.rs
@@ -544,21 +544,11 @@ mod tests {
 
     #[test]
     fn invalid_style_index_returns_error() {
-        let path = invalid_style_workbook_path();
+        let path = invalid_workbook_path("style");
         write_invalid_style_workbook(&path);
 
         let mut spreadsheet = XlsxSpreadsheet::open(path.to_str().unwrap()).unwrap();
-        let result = spreadsheet.read_sheets(&Criteria {
-            sheet_name_patterns: None,
-            sheet_limit: None,
-            range: None,
-            rows_limit: None,
-            nulls: HashSet::from(["".to_string()]),
-            error_as_null: false,
-            skip_empty_rows: false,
-            end_at_empty_row: false,
-            spread_merged_cells: false,
-        });
+        let result = spreadsheet.read_sheets(&default_criteria());
 
         std::fs::remove_file(path).unwrap();
         let error = match result {
@@ -570,18 +560,50 @@ mod tests {
         assert!(error.contains("workbook defines 1 styles"));
     }
 
-    fn invalid_style_workbook_path() -> PathBuf {
+    #[test]
+    fn invalid_shared_string_index_returns_error() {
+        let path = invalid_workbook_path("shared-string");
+        write_invalid_shared_string_workbook(&path);
+
+        let mut spreadsheet = XlsxSpreadsheet::open(path.to_str().unwrap()).unwrap();
+        let result = spreadsheet.analyze_sheets(true, &default_criteria(), &Vec::new());
+
+        std::fs::remove_file(path).unwrap();
+        let error = match result {
+            Ok(_) => panic!("expected invalid shared string index error"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("Sheet1!A1"));
+        assert!(error.contains("invalid shared string index 999"));
+    }
+
+    fn invalid_workbook_path(kind: &str) -> PathBuf {
         let id = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        std::env::temp_dir().join(format!("rusty-sheet-invalid-style-{id}.xlsx"))
+        std::env::temp_dir().join(format!("rusty-sheet-invalid-{kind}-{id}.xlsx"))
+    }
+
+    fn default_criteria() -> Criteria {
+        Criteria {
+            sheet_name_patterns: None,
+            sheet_limit: None,
+            range: None,
+            rows_limit: None,
+            nulls: HashSet::from(["".to_string()]),
+            error_as_null: false,
+            skip_empty_rows: false,
+            end_at_empty_row: false,
+            spread_merged_cells: false,
+        }
     }
 
     fn write_invalid_style_workbook(path: &Path) {
         let file = File::create(path).unwrap();
         let mut zip = ZipWriter::new(file);
-        let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
         let rows = (2..11)
             .map(|row| format!("<row r=\"{row}\"><c r=\"A{row}\"><v>{row}</v></c></row>"))
             .collect::<String>();
@@ -634,6 +656,67 @@ mod tests {
 </styleSheet>"#.to_string(),
             ),
             ("xl/worksheets/sheet1.xml", sheet),
+        ] {
+            zip.start_file(name, options).unwrap();
+            zip.write_all(content.as_bytes()).unwrap();
+        }
+        zip.finish().unwrap();
+    }
+
+    fn write_invalid_shared_string_workbook(path: &Path) {
+        let file = File::create(path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+        for (name, content) in [
+            (
+                "[Content_Types].xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
+</Types>"#.to_string(),
+            ),
+            (
+                "_rels/.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"#.to_string(),
+            ),
+            (
+                "xl/workbook.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+</workbook>"#.to_string(),
+            ),
+            (
+                "xl/_rels/workbook.xml.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>
+</Relationships>"#.to_string(),
+            ),
+            (
+                "xl/sharedStrings.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="1" uniqueCount="1">
+  <si><t>name</t></si>
+</sst>"#.to_string(),
+            ),
+            (
+                "xl/worksheets/sheet1.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData><row r="1"><c r="A1" t="s"><v>999</v></c></row></sheetData>
+</worksheet>"#.to_string(),
+            ),
         ] {
             zip.start_file(name, options).unwrap();
             zip.write_all(content.as_bytes()).unwrap();

--- a/src/spreadsheet/xlsx.rs
+++ b/src/spreadsheet/xlsx.rs
@@ -208,9 +208,17 @@ impl Spreadsheet for XlsxSpreadsheet {
                     col_count = 0;
                 }
                 Event::Start(event) if event.name() == TAG_CELL => {
-                    (row, col) = event.get_attribute_value("r")?
-                        .and_then(|reference| reference_to_index(&reference))
-                        .unwrap_or((row_count, col_count));
+                    if let Some(reference) = event.get_attribute_value("r")? {
+                        (row, col) = reference_to_index(&reference).ok_or_else(|| {
+                            SpreadsheetError::CellReferenceError(
+                                sheet.file_name.to_owned(),
+                                sheet.name.to_owned(),
+                                reference.to_string(),
+                            )
+                        })?;
+                    } else {
+                        (row, col) = (row_count, col_count);
+                    }
                     col_count += 1;
                     if sheet.after_row_upper_bound(row) {
                         break;
@@ -577,6 +585,23 @@ mod tests {
         assert!(error.contains("invalid shared string index 999"));
     }
 
+    #[test]
+    fn invalid_cell_reference_returns_error() {
+        let path = invalid_workbook_path("cell-reference");
+        write_invalid_cell_reference_workbook(&path);
+
+        let mut spreadsheet = XlsxSpreadsheet::open(path.to_str().unwrap()).unwrap();
+        let result = spreadsheet.read_sheets(&default_criteria());
+
+        std::fs::remove_file(path).unwrap();
+        let error = match result {
+            Ok(_) => panic!("expected invalid cell reference error"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("Sheet1"));
+        assert!(error.contains("invalid cell reference 'XFE1'"));
+    }
+
     fn invalid_workbook_path(kind: &str) -> PathBuf {
         let id = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -715,6 +740,58 @@ mod tests {
                 r#"<?xml version="1.0" encoding="UTF-8"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
   <sheetData><row r="1"><c r="A1" t="s"><v>999</v></c></row></sheetData>
+</worksheet>"#.to_string(),
+            ),
+        ] {
+            zip.start_file(name, options).unwrap();
+            zip.write_all(content.as_bytes()).unwrap();
+        }
+        zip.finish().unwrap();
+    }
+
+    fn write_invalid_cell_reference_workbook(path: &Path) {
+        let file = File::create(path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+        for (name, content) in [
+            (
+                "[Content_Types].xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>"#.to_string(),
+            ),
+            (
+                "_rels/.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"#.to_string(),
+            ),
+            (
+                "xl/workbook.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+</workbook>"#.to_string(),
+            ),
+            (
+                "xl/_rels/workbook.xml.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"#.to_string(),
+            ),
+            (
+                "xl/worksheets/sheet1.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData><row r="1"><c r="XFE1" t="inlineStr"><is><t>value</t></is></c></row></sheetData>
 </worksheet>"#.to_string(),
             ),
         ] {

--- a/src/spreadsheet/xlsx.rs
+++ b/src/spreadsheet/xlsx.rs
@@ -15,6 +15,7 @@ use crate::spreadsheet::excel;
 use crate::spreadsheet::excel::load_relationships;
 use crate::spreadsheet::reference::index_to_reference;
 use crate::spreadsheet::reference::reference_to_index;
+use crate::spreadsheet::resolve_number_format;
 use crate::spreadsheet::sheet::Sheet;
 use quick_xml::events::Event;
 use quick_xml::name::QName;
@@ -231,7 +232,14 @@ impl Spreadsheet for XlsxSpreadsheet {
                         if let Some(format_id) = event.get_attribute_value("s")? {
                             if kind == CellType::Number && !format_id.is_empty() {
                                 let index = format_id.parse::<usize>()?;
-                                kind = self.number_formats[index];
+                                kind = resolve_number_format(
+                                    &self.number_formats,
+                                    &sheet.file_name,
+                                    &sheet.name,
+                                    row,
+                                    col,
+                                    index,
+                                )?;
                             }
                         }
                     } else {
@@ -518,4 +526,118 @@ fn read_string_value(
         Event::GeneralRef(event) if is_text => text.push_bytes_ref(&event)?,
     });
     Ok(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spreadsheet::criteria::Criteria;
+    use std::collections::HashSet;
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::Path;
+    use std::path::PathBuf;
+    use std::time::SystemTime;
+    use std::time::UNIX_EPOCH;
+    use zip::write::SimpleFileOptions;
+    use zip::ZipWriter;
+
+    #[test]
+    fn invalid_style_index_returns_error() {
+        let path = invalid_style_workbook_path();
+        write_invalid_style_workbook(&path);
+
+        let mut spreadsheet = XlsxSpreadsheet::open(path.to_str().unwrap()).unwrap();
+        let result = spreadsheet.read_sheets(&Criteria {
+            sheet_name_patterns: None,
+            sheet_limit: None,
+            range: None,
+            rows_limit: None,
+            nulls: HashSet::from(["".to_string()]),
+            error_as_null: false,
+            skip_empty_rows: false,
+            end_at_empty_row: false,
+            spread_merged_cells: false,
+        });
+
+        std::fs::remove_file(path).unwrap();
+        let error = match result {
+            Ok(_) => panic!("expected invalid style index error"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("Sheet1!A11"));
+        assert!(error.contains("invalid style index 999"));
+        assert!(error.contains("workbook defines 1 styles"));
+    }
+
+    fn invalid_style_workbook_path() -> PathBuf {
+        let id = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("rusty-sheet-invalid-style-{id}.xlsx"))
+    }
+
+    fn write_invalid_style_workbook(path: &Path) {
+        let file = File::create(path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        let rows = (2..11)
+            .map(|row| format!("<row r=\"{row}\"><c r=\"A{row}\"><v>{row}</v></c></row>"))
+            .collect::<String>();
+        let sheet = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>value</t></is></c></row>{rows}<row r="11"><c r="A11" s="999"><v>11</v></c></row></sheetData>
+</worksheet>"#
+        );
+
+        for (name, content) in [
+            (
+                "[Content_Types].xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+</Types>"#.to_string(),
+            ),
+            (
+                "_rels/.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"#.to_string(),
+            ),
+            (
+                "xl/workbook.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+</workbook>"#.to_string(),
+            ),
+            (
+                "xl/_rels/workbook.xml.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+</Relationships>"#.to_string(),
+            ),
+            (
+                "xl/styles.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <cellXfs count="1"><xf numFmtId="0"/></cellXfs>
+</styleSheet>"#.to_string(),
+            ),
+            ("xl/worksheets/sheet1.xml", sheet),
+        ] {
+            zip.start_file(name, options).unwrap();
+            zip.write_all(content.as_bytes()).unwrap();
+        }
+        zip.finish().unwrap();
+    }
 }


### PR DESCRIPTION
Codex:
> Stack order: this PR is intended to follow PR [#24](https://github.com/redraiment/rusty-sheet/pull/24), which follows PR [#23](https://github.com/redraiment/rusty-sheet/pull/23). GitHub cannot base this upstream PR on fork-only parent branches, and I do not have permission to create upstream stack base branches, so this is temporarily opened against `main`.
>
> This PR prevents malformed spreadsheet cell coordinates from reaching panic-prone reference formatting.
>
> Explicit XLSX references outside Excel bounds, such as `XFE1`, were previously accepted as ordinary row/column indexes. Binary XLS/XLSB cells can also carry impossible coordinates into error reporting; combining one with an invalid style index could panic while formatting the error itself.
>
> Changes:
> - Bound cell-reference parsing to Excel columns `A:XFD` and rows `1:1048576`.
> - Reject row zero and checked-arithmetic overflow in row/column parsing.
> - Return a spreadsheet error for invalid explicit XLSX cell references, while preserving fallback behavior for cells that omit a reference.
> - Preserve A1 diagnostics for valid coordinates and use R1C1 notation for impossible binary coordinates.
> - Add parser-boundary, malformed XLSX, and invalid binary-coordinate/style regressions.
>
> Verification:
> - `cargo test --locked --lib` (14 tests): passed.
> - `git diff --check`: passed.
>
> Note: `cargo fmt --check` is currently noisy on existing repo-wide formatting drift, so I did not reformat unrelated files.
