### PR TITLE
Avoid panicking on missing spreadsheet XML parts

### DIFF
--- a/src/extension/writer.rs
+++ b/src/extension/writer.rs
@@ -43,7 +43,7 @@ pub(super) fn write_to_vector(sheet: &Sheet, column: &Column, cell: &Cell, vecto
         cell
     };
     match column.kind {
-        ColumnType::Varchar => vector.insert(row, &cell.to_string()),
+        ColumnType::Varchar => vector.insert(row, &cell.to_display_string().map_err(mapper)?),
         ColumnType::Boolean => write_primitive(vector, row, cell.to_boolean()),
         ColumnType::BigInt => write_primitive(vector, row, cell.to_bigint().map_err(mapper)?),
         ColumnType::Double => write_primitive(vector, row, cell.to_double().map_err(mapper)?),

--- a/src/extension/writer.rs
+++ b/src/extension/writer.rs
@@ -3,15 +3,16 @@
 use crate::database::column::Column;
 use crate::database::column::ColumnType;
 use crate::error::RustySheetError;
+use crate::spreadsheet::SpreadsheetError;
 use crate::spreadsheet::cell::Cell;
 use crate::spreadsheet::cell::CellType;
+use crate::spreadsheet::resolve_loaded_shared_string;
+use crate::spreadsheet::sheet::Sheet;
 use duckdb::core::FlatVector;
 use duckdb::core::Inserter;
 use libduckdb_sys::duckdb_date;
 use libduckdb_sys::duckdb_time;
 use libduckdb_sys::duckdb_timestamp;
-use crate::spreadsheet::sheet::Sheet;
-use crate::spreadsheet::SpreadsheetError;
 
 /// Writes a cell value to a DuckDB vector based on column type.
 /// Handles type conversion and error mapping for different data types.
@@ -25,8 +26,9 @@ pub(super) fn write_to_vector(sheet: &Sheet, column: &Column, cell: &Cell, vecto
         )
     };
     let cell = if cell.kind == CellType::SharedString {
-        let index = cell.value.parse::<usize>()?;
-        if let Some(shared_string) = &shared_strings[index] {
+        if let Some(shared_string) =
+            resolve_loaded_shared_string(shared_strings, &sheet.file_name, &sheet.name, cell)?
+        {
             &Cell {
                 row: cell.row,
                 col: cell.col,

--- a/src/helpers/biff12.rs
+++ b/src/helpers/biff12.rs
@@ -42,15 +42,14 @@ impl<R: BufRead> Biff12Reader<R> {
         &'_ self,
         at: usize,
     ) -> Result<(Cow<'_, str>, usize), RustySheetError> {
-        let lower_bound = at + 4usize;
-        let size = to_usize(&self.buffer[at..at + lower_bound]);
-        let upper_bound = lower_bound + size * 2;
-        if self.buffer.len() >= upper_bound {
-            let (value, _, _) = UTF_16LE.decode(&self.buffer[lower_bound..upper_bound]);
-            Ok((value, upper_bound))
-        } else {
-            Err(Biff12Error::NoEnoughData(upper_bound, self.buffer.len()))?
-        }
+        let size = self.get_usize(at)?;
+        let lower_bound = checked_offset(at, 4, self.buffer.len())?;
+        let byte_length = size
+            .checked_mul(2)
+            .ok_or(Biff12Error::NoEnoughData(usize::MAX, self.buffer.len()))?;
+        let upper_bound = checked_offset(lower_bound, byte_length, self.buffer.len())?;
+        let (value, _, _) = UTF_16LE.decode(self.slice(lower_bound, byte_length)?);
+        Ok((value, upper_bound))
     }
 
     /// Reads a UTF-16 string from the specified position
@@ -60,33 +59,39 @@ impl<R: BufRead> Biff12Reader<R> {
     }
 
     /// Reads a usize value from the specified position
-    pub(crate) fn get_usize(&'_ self, at: usize) -> usize {
-        to_usize(&self.buffer[at..at + 4])
+    pub(crate) fn get_usize(&'_ self, at: usize) -> Result<usize, RustySheetError> {
+        Ok(to_usize(self.slice(at, 4)?))
     }
 
     /// Reads a u16 value from the specified position
-    pub(crate) fn get_u16(&'_ self, at: usize) -> u16 {
-        to_u16(&self.buffer[at..at + 2])
+    pub(crate) fn get_u16(&'_ self, at: usize) -> Result<u16, RustySheetError> {
+        Ok(to_u16(self.slice(at, 2)?))
     }
 
     /// Reads a u32 value from the specified position
-    pub(crate) fn get_u32(&'_ self, at: usize) -> u32 {
-        to_u32(&self.buffer[at..at + 4])
+    pub(crate) fn get_u32(&'_ self, at: usize) -> Result<u32, RustySheetError> {
+        Ok(to_u32(self.slice(at, 4)?))
     }
 
     /// Reads an i32 value from the specified position
-    pub(crate) fn get_i32(&'_ self, at: usize) -> i32 {
-        to_i32(&self.buffer[at..at + 4])
+    pub(crate) fn get_i32(&'_ self, at: usize) -> Result<i32, RustySheetError> {
+        Ok(to_i32(self.slice(at, 4)?))
     }
 
     /// Reads an f64 value from the specified position
-    pub(crate) fn get_f64(&'_ self, at: usize) -> f64 {
-        to_f64(&self.buffer[at..at + 8])
+    pub(crate) fn get_f64(&'_ self, at: usize) -> Result<f64, RustySheetError> {
+        Ok(to_f64(self.slice(at, 8)?))
     }
 
     /// Reads a style index from the specified position (3 bytes, padded to 4)
-    pub(crate) fn get_style(&'_ self, at: usize) -> usize {
-        to_usize(&[self.buffer[at], self.buffer[at + 1], self.buffer[at + 2], 0])
+    pub(crate) fn get_style(&'_ self, at: usize) -> Result<usize, RustySheetError> {
+        let bytes = self.slice(at, 3)?;
+        Ok(to_usize(&[bytes[0], bytes[1], bytes[2], 0]))
+    }
+
+    /// Reads a byte from the specified position
+    pub(crate) fn get_u8(&'_ self, at: usize) -> Result<u8, RustySheetError> {
+        Ok(self.slice(at, 1)?[0])
     }
 
     /// Reads a 7-bit continuation integer with the specified byte limit
@@ -149,6 +154,46 @@ impl<R: BufRead> Biff12Reader<R> {
     /// Finds a record of the specified type without any skip ranges
     pub(crate) fn find(&mut self, target: u16) -> Result<usize, RustySheetError> {
         self.find_with(target, &[])
+    }
+
+    fn slice(&self, at: usize, length: usize) -> Result<&[u8], RustySheetError> {
+        let upper_bound = checked_offset(at, length, self.buffer.len())?;
+        Ok(&self.buffer[at..upper_bound])
+    }
+}
+
+fn checked_offset(at: usize, length: usize, actual: usize) -> Result<usize, Biff12Error> {
+    let upper_bound = at
+        .checked_add(length)
+        .ok_or(Biff12Error::NoEnoughData(usize::MAX, actual))?;
+    if upper_bound <= actual {
+        Ok(upper_bound)
+    } else {
+        Err(Biff12Error::NoEnoughData(upper_bound, actual))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn fixed_width_reads_return_errors_for_short_records() {
+        let mut reader = Biff12Reader::new(Cursor::new(Vec::new()));
+        reader.buffer = vec![0; 8];
+
+        assert!(reader.get_f64(1).unwrap_err().to_string().contains("No enough data"));
+        assert!(reader.get_style(6).unwrap_err().to_string().contains("No enough data"));
+    }
+
+    #[test]
+    fn string_reads_return_errors_for_short_records() {
+        let mut reader = Biff12Reader::new(Cursor::new(Vec::new()));
+        reader.buffer = vec![2, 0, 0, 0, b'a'];
+
+        assert!(reader.get_str(0).unwrap_err().to_string().contains("No enough data"));
+        assert!(reader.get_str(3).unwrap_err().to_string().contains("No enough data"));
     }
 }
 

--- a/src/spreadsheet/cell.rs
+++ b/src/spreadsheet/cell.rs
@@ -243,76 +243,36 @@ impl Cell {
             _ => Err(format!("parse '{}' to datetime failed", self.value))?,
         }
     }
-}
 
-impl Display for Cell {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let value = match self.kind {
-            CellType::Boolean => if self.value == "1" { "true" } else { "false" }.to_owned(),
-            CellType::NumberDateTime1900 => {
-                if let Ok(value) = to_datetime_string(&self.value, false) {
-                    value
-                } else {
-                    panic!(
-                        "Parse cell value '{}' at {} to DateTime(1900) failed",
-                        self.value,
-                        self.reference()
-                    );
-                }
-            }
-            CellType::NumberDate1900 => {
-                if let Ok(value) = to_date_string(&self.value, false) {
-                    value
-                } else {
-                    panic!(
-                        "Parse cell value '{}' at {} to Date(1900) failed",
-                        self.value,
-                        self.reference()
-                    );
-                }
-            }
-            CellType::NumberDateTime1904 => {
-                if let Ok(value) = to_datetime_string(&self.value, true) {
-                    value
-                } else {
-                    panic!(
-                        "Parse cell value '{}' at {} to DateTime(1904) failed",
-                        self.value,
-                        self.reference()
-                    );
-                }
-            }
-            CellType::NumberDate1904 => {
-                if let Ok(value) = to_date_string(&self.value, true) {
-                    value
-                } else {
-                    panic!(
-                        "Parse cell value '{}' at {} to Date(1904) failed",
-                        self.value,
-                        self.reference()
-                    );
-                }
-            }
-            CellType::NumberTime1900 | CellType::NumberTime1904 => {
-                if let Ok(value) = to_time_string(&self.value) {
-                    value
-                } else {
-                    panic!(
-                        "Parse cell value '{}' at {} to Time failed",
-                        self.value,
-                        self.reference()
-                    );
-                }
-            }
-            CellType::IsoDateTime => self.value.replace("T", " "),
-            CellType::IsoDuration => self
+    /// Converts the cell to the user-visible string representation.
+    pub(crate) fn to_display_string(&self) -> Result<String, String> {
+        match self.kind {
+            CellType::Boolean => Ok(if self.value == "1" { "true" } else { "false" }.to_owned()),
+            CellType::NumberDateTime1900 => to_datetime_string(&self.value, false)
+                .map_err(|_| format!("parse '{}' to DateTime(1900) failed", self.value)),
+            CellType::NumberDate1900 => to_date_string(&self.value, false)
+                .map_err(|_| format!("parse '{}' to Date(1900) failed", self.value)),
+            CellType::NumberDateTime1904 => to_datetime_string(&self.value, true)
+                .map_err(|_| format!("parse '{}' to DateTime(1904) failed", self.value)),
+            CellType::NumberDate1904 => to_date_string(&self.value, true)
+                .map_err(|_| format!("parse '{}' to Date(1904) failed", self.value)),
+            CellType::NumberTime1900 | CellType::NumberTime1904 => to_time_string(&self.value)
+                .map_err(|_| format!("parse '{}' to Time failed", self.value)),
+            CellType::IsoDateTime => Ok(self.value.replace("T", " ")),
+            CellType::IsoDuration => Ok(self
                 .value
                 .replace("PT", "")
                 .replace("H", ":")
                 .replace("M", ":")
-                .replace("S", ""),
-            _ => self.value.to_owned(),
-        };
+                .replace("S", "")),
+            _ => Ok(self.value.to_owned()),
+        }
+    }
+}
+
+impl Display for Cell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = self.to_display_string().unwrap_or_else(|_| self.value.to_owned());
         write!(f, "{}", value)
     }
 }

--- a/src/spreadsheet/mod.rs
+++ b/src/spreadsheet/mod.rs
@@ -46,6 +46,29 @@ pub(crate) fn resolve_number_format(
     })
 }
 
+#[cfg(test)]
+mod number_format_tests {
+    use super::*;
+
+    #[test]
+    fn invalid_style_with_out_of_range_column_returns_error() {
+        let error = resolve_number_format(
+            &[CellType::Number],
+            "workbook.xlsb",
+            "Sheet1",
+            10,
+            16_384,
+            999,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Cell '[workbook.xlsb]Sheet1!R11C16385': invalid style index 999; workbook defines 1 styles"
+        );
+    }
+}
+
 pub(crate) fn resolve_shared_string<'a>(
     shared_strings: &'a [String],
     mappings: &HashMap<usize, usize>,
@@ -127,6 +150,10 @@ pub(crate) enum SpreadsheetError {
     /// Error indicating a shared string index is outside the workbook's shared string table.
     #[error("Cell '[{0}]{1}!{2}': invalid shared string index {3}")]
     CellSharedStringIndexError(String, String, String, usize),
+
+    /// Error indicating a worksheet cell reference is outside the supported spreadsheet bounds.
+    #[error("Sheet '[{0}]{1}': invalid cell reference '{2}'")]
+    CellReferenceError(String, String, String),
 }
 
 pub(crate) trait Spreadsheet {

--- a/src/spreadsheet/mod.rs
+++ b/src/spreadsheet/mod.rs
@@ -27,6 +27,25 @@ pub(crate) mod xlsx;
 pub(crate) mod criteria;
 pub(crate) mod sheet;
 
+pub(crate) fn resolve_number_format(
+    number_formats: &[CellType],
+    file_name: &str,
+    sheet_name: &str,
+    row: usize,
+    col: usize,
+    style_index: usize,
+) -> Result<CellType, SpreadsheetError> {
+    number_formats.get(style_index).copied().ok_or_else(|| {
+        SpreadsheetError::CellStyleIndexError(
+            file_name.to_owned(),
+            sheet_name.to_owned(),
+            crate::spreadsheet::reference::index_to_reference(row, col),
+            style_index,
+            number_formats.len(),
+        )
+    })
+}
+
 #[derive(Error, Debug)]
 pub(crate) enum SpreadsheetError {
     /// Error indicating the spreadsheet format is not supported
@@ -48,6 +67,10 @@ pub(crate) enum SpreadsheetError {
     /// Error indicating a specific cell value is invalid
     #[error("Cell '[{0}]{1}!{2}': {3}")]
     CellValueError(String, String, String, String),
+
+    /// Error indicating a cell style index is outside the workbook's style table.
+    #[error("Cell '[{0}]{1}!{2}': invalid style index {3}; workbook defines {4} styles")]
+    CellStyleIndexError(String, String, String, usize, usize),
 }
 
 pub(crate) trait Spreadsheet {

--- a/src/spreadsheet/mod.rs
+++ b/src/spreadsheet/mod.rs
@@ -46,6 +46,58 @@ pub(crate) fn resolve_number_format(
     })
 }
 
+pub(crate) fn resolve_shared_string<'a>(
+    shared_strings: &'a [String],
+    mappings: &HashMap<usize, usize>,
+    file_name: &str,
+    sheet_name: &str,
+    cell: &Cell,
+) -> Result<&'a str, RustySheetError> {
+    let shared_string_index = cell.value.parse::<usize>()?;
+    let mapped_index = mappings.get(&shared_string_index).copied().ok_or_else(|| {
+        SpreadsheetError::CellSharedStringIndexError(
+            file_name.to_owned(),
+            sheet_name.to_owned(),
+            cell.reference(),
+            shared_string_index,
+        )
+    })?;
+
+    shared_strings
+        .get(mapped_index)
+        .map(String::as_str)
+        .ok_or_else(|| {
+            SpreadsheetError::CellSharedStringIndexError(
+                file_name.to_owned(),
+                sheet_name.to_owned(),
+                cell.reference(),
+                shared_string_index,
+            )
+            .into()
+        })
+}
+
+pub(crate) fn resolve_loaded_shared_string<'a>(
+    shared_strings: &'a [Option<String>],
+    file_name: &str,
+    sheet_name: &str,
+    cell: &Cell,
+) -> Result<Option<&'a str>, RustySheetError> {
+    let shared_string_index = cell.value.parse::<usize>()?;
+    shared_strings
+        .get(shared_string_index)
+        .map(Option::as_deref)
+        .ok_or_else(|| {
+            SpreadsheetError::CellSharedStringIndexError(
+                file_name.to_owned(),
+                sheet_name.to_owned(),
+                cell.reference(),
+                shared_string_index,
+            )
+            .into()
+        })
+}
+
 #[derive(Error, Debug)]
 pub(crate) enum SpreadsheetError {
     /// Error indicating the spreadsheet format is not supported
@@ -71,6 +123,10 @@ pub(crate) enum SpreadsheetError {
     /// Error indicating a cell style index is outside the workbook's style table.
     #[error("Cell '[{0}]{1}!{2}': invalid style index {3}; workbook defines {4} styles")]
     CellStyleIndexError(String, String, String, usize, usize),
+
+    /// Error indicating a shared string index is outside the workbook's shared string table.
+    #[error("Cell '[{0}]{1}!{2}': invalid shared string index {3}")]
+    CellSharedStringIndexError(String, String, String, usize),
 }
 
 pub(crate) trait Spreadsheet {
@@ -132,56 +188,71 @@ pub(crate) trait Spreadsheet {
         let (shared_strings, mappings) = self.load_shared_strings(Some(shared_indexes))?;
 
         let mut tables = Vec::<Table>::new();
-        for (name, header, data, row_lower_bound, col_lower_bound, col_upper_bound) in sheets.into_iter() {
-            let names = (col_lower_bound..=col_upper_bound).map(|col| {
-                let index = col - col_lower_bound;
-                if let Some(cell) = &header[index] {
-                    let value = if cell.kind == CellType::SharedString {
-                        let id = cell.value.parse::<usize>().expect("Shared string index");
-                        let index = mappings[&id];
-                        shared_strings[index].to_owned()
-                    } else {
-                        cell.to_string()
-                    };
-                    if !criteria.nulls.contains(&value) {
-                        value
-                    } else {
-                        index_to_col(col).to_owned()
-                    }
-                } else {
-                    index_to_col(col).to_owned()
-                }
-            }).collect::<Vec<_>>();
-
-            let columns = names.iter().zip(data)
-                .map(|(name, cells)| {
-                    let types = cells.iter()
-                        .map(|cell| {
-                            if cell.kind == CellType::SharedString {
-                                let id = cell.value.parse::<usize>().expect("Shared string index");
-                                let index = mappings[&id];
-                                let value = shared_strings[index].as_str();
-                                ColumnType::from(if criteria.nulls.contains(value) {
-                                    &CellType::Empty
-                                } else {
-                                    &cell.kind
-                                }, value)
-                            } else {
-                                ColumnType::from(&cell.kind, &cell.value)
-                            }
+        let file_name = self.name();
+        for (sheet_name, header, data, row_lower_bound, col_lower_bound, col_upper_bound) in sheets.into_iter() {
+            let names = (col_lower_bound..=col_upper_bound)
+                .map(|col| -> Result<String, RustySheetError> {
+                    let index = col - col_lower_bound;
+                    if let Some(cell) = &header[index] {
+                        let value = if cell.kind == CellType::SharedString {
+                            resolve_shared_string(
+                                &shared_strings,
+                                &mappings,
+                                &file_name,
+                                &sheet_name,
+                                cell,
+                            )?.to_owned()
+                        } else {
+                            cell.to_string()
+                        };
+                        Ok(if !criteria.nulls.contains(&value) {
+                            value
+                        } else {
+                            index_to_col(col).to_owned()
                         })
-                        .collect::<Vec<_>>();
-                    Column {
-                        name: name.to_owned(),
-                        kind: presets.iter()
-                            .find(|(pattern, _)| pattern.matches(name))
-                            .map(|(_, kind)| kind.to_owned())
-                            .unwrap_or(ColumnType::detect(types)),
+                    } else {
+                        Ok(index_to_col(col).to_owned())
                     }
                 })
-                .collect::<Vec<_>>();
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let columns = names.iter().zip(data)
+                .map(|(column_name, cells)| -> Result<Column, RustySheetError> {
+                    let types = cells.iter()
+                        .map(|cell| -> Result<Option<ColumnType>, RustySheetError> {
+                            if cell.kind == CellType::SharedString {
+                                let value = resolve_shared_string(
+                                    &shared_strings,
+                                    &mappings,
+                                    &file_name,
+                                    &sheet_name,
+                                    cell,
+                                )?;
+                                Ok(ColumnType::from(
+                                    if criteria.nulls.contains(value) {
+                                        &CellType::Empty
+                                    } else {
+                                        &cell.kind
+                                    },
+                                    value,
+                                ))
+                            } else {
+                                Ok(ColumnType::from(&cell.kind, &cell.value))
+                            }
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    Ok(Column {
+                        name: column_name.to_owned(),
+                        kind: presets
+                            .iter()
+                            .find(|(pattern, _)| pattern.matches(column_name))
+                            .map(|(_, kind)| kind.to_owned())
+                            .unwrap_or(ColumnType::detect(types)),
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
             tables.push(Table {
-                name,
+                name: sheet_name,
                 columns,
                 row_lower_bound,
                 col_lower_bound,

--- a/src/spreadsheet/mod.rs
+++ b/src/spreadsheet/mod.rs
@@ -230,7 +230,14 @@ pub(crate) trait Spreadsheet {
                                 cell,
                             )?.to_owned()
                         } else {
-                            cell.to_string()
+                            cell.to_display_string().map_err(|message| {
+                                SpreadsheetError::CellValueError(
+                                    file_name.to_owned(),
+                                    sheet_name.to_owned(),
+                                    cell.reference(),
+                                    message,
+                                )
+                            })?
                         };
                         Ok(if !criteria.nulls.contains(&value) {
                             value

--- a/src/spreadsheet/ods.rs
+++ b/src/spreadsheet/ods.rs
@@ -1,6 +1,7 @@
 use crate::error::RustySheetError;
 use crate::helpers::reader::UnifiedReader;
 use crate::helpers::xml::XmlNodeHelper;
+use crate::helpers::xml::XmlReader;
 use crate::helpers::xml::XmlTextContextHelper;
 use crate::helpers::zip::ZipHelper;
 use crate::match_xml_events;
@@ -15,8 +16,10 @@ use quick_xml::events::Event;
 use quick_xml::name::QName;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::io::BufReader;
 use std::io::Read;
 use thiserror::Error;
+use zip::read::ZipFile;
 use zip::ZipArchive;
 
 /// ODS file MIME type identifier
@@ -111,14 +114,14 @@ impl Spreadsheet for OdsSpreadsheet {
         let mut sheets = Vec::<Sheet>::new();
         let mut sheet_count = 0usize;
         let mut sheet_name = String::new();
-        let mut reader = self.zip
-            .xml_reader("content.xml")?
-            .expect("content.xml");
+        let mut reader = required_xml_reader(&mut self.zip, "content.xml")?;
         'sheets: loop {
             match_xml_events!(reader => {
                 Event::End(event) if event.name() == SPREADSHEET => break 'sheets,
                 Event::Start(event) if event.name() == TABLE => {
-                    let table_name = event.get_attribute_value("table:name")?.expect("Sheet name");
+                    let table_name = event
+                        .get_attribute_value("table:name")?
+                        .ok_or_else(|| SpreadsheetError::FileError("content.xml".to_string()))?;
                     sheet_name.clear();
                     sheet_name.push_str(&table_name);
                     if criteria.sheet_limit.map(|limit| sheet_count >= limit).unwrap_or(false) {
@@ -298,9 +301,7 @@ fn check_mime(zip: &mut ZipArchive<UnifiedReader>) -> Result<(), RustySheetError
 /// # Returns
 /// * `Result<bool, RustySheetError>` - True if password protected, false otherwise
 fn is_password_protected(zip: &mut ZipArchive<UnifiedReader>) -> Result<bool, RustySheetError> {
-    let mut reader = zip
-        .xml_reader("META-INF/manifest.xml")?
-        .expect("META-INF/manifest.xml");
+    let mut reader = required_xml_reader(zip, "META-INF/manifest.xml")?;
     let mut in_file_entry = false;
     match_xml_events!(reader => {
         Event::Start(event) if event.name() == QName(b"manifest:file-entry") => in_file_entry = true,
@@ -309,4 +310,141 @@ fn is_password_protected(zip: &mut ZipArchive<UnifiedReader>) -> Result<bool, Ru
         }
     });
     Ok(false)
+}
+
+fn required_xml_reader<'a>(
+    zip: &'a mut ZipArchive<UnifiedReader>,
+    path: &str,
+) -> Result<XmlReader<BufReader<ZipFile<'a, UnifiedReader>>>, RustySheetError> {
+    zip.xml_reader(path)?.ok_or_else(|| {
+        RustySheetError::from(SpreadsheetError::FileError(path.to_string()))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spreadsheet::criteria::Criteria;
+    use std::collections::HashSet;
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::Path;
+    use std::path::PathBuf;
+    use std::time::SystemTime;
+    use std::time::UNIX_EPOCH;
+    use zip::write::SimpleFileOptions;
+    use zip::ZipWriter;
+
+    #[test]
+    fn missing_manifest_xml_returns_error() {
+        let path = ods_path("missing-manifest");
+        write_ods(&path, false, Some(valid_content_xml()));
+
+        let result = OdsSpreadsheet::open(path.to_str().unwrap());
+
+        std::fs::remove_file(path).unwrap();
+        let error = match result {
+            Ok(_) => panic!("expected missing manifest XML error"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("META-INF/manifest.xml"));
+        assert!(error.contains("missing or corrupted"));
+    }
+
+    #[test]
+    fn missing_content_xml_returns_error() {
+        let path = ods_path("missing-content");
+        write_ods(&path, true, None);
+
+        let mut spreadsheet = OdsSpreadsheet::open(path.to_str().unwrap()).unwrap();
+        let result = spreadsheet.read_sheets(&default_criteria());
+
+        std::fs::remove_file(path).unwrap();
+        let error = match result {
+            Ok(_) => panic!("expected missing content XML error"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("content.xml"));
+        assert!(error.contains("missing or corrupted"));
+    }
+
+    #[test]
+    fn missing_table_name_returns_error() {
+        let path = ods_path("missing-table-name");
+        write_ods(&path, true, Some(unnamed_table_content_xml()));
+
+        let mut spreadsheet = OdsSpreadsheet::open(path.to_str().unwrap()).unwrap();
+        let result = spreadsheet.read_sheets(&default_criteria());
+
+        std::fs::remove_file(path).unwrap();
+        let error = match result {
+            Ok(_) => panic!("expected missing table name error"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("content.xml"));
+        assert!(error.contains("missing or corrupted"));
+    }
+
+    fn default_criteria() -> Criteria {
+        Criteria {
+            sheet_name_patterns: None,
+            sheet_limit: None,
+            range: None,
+            rows_limit: None,
+            nulls: HashSet::from(["".to_string()]),
+            error_as_null: false,
+            skip_empty_rows: false,
+            end_at_empty_row: false,
+            spread_merged_cells: false,
+        }
+    }
+
+    fn ods_path(kind: &str) -> PathBuf {
+        let id = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("rusty-sheet-invalid-{kind}-{id}.ods"))
+    }
+
+    fn write_ods(path: &Path, include_manifest: bool, content_xml: Option<&str>) {
+        let file = File::create(path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+        zip.start_file("mimetype", options).unwrap();
+        zip.write_all(MIME_TYPE).unwrap();
+
+        if include_manifest {
+            zip.start_file("META-INF/manifest.xml", options).unwrap();
+            zip.write_all(manifest_xml().as_bytes()).unwrap();
+        }
+        if let Some(content_xml) = content_xml {
+            zip.start_file("content.xml", options).unwrap();
+            zip.write_all(content_xml.as_bytes()).unwrap();
+        }
+        zip.finish().unwrap();
+    }
+
+    fn manifest_xml() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0">
+  <manifest:file-entry manifest:full-path="/" manifest:media-type="application/vnd.oasis.opendocument.spreadsheet"/>
+</manifest:manifest>"#
+    }
+
+    fn valid_content_xml() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0">
+  <office:body><office:spreadsheet><table:table table:name="Sheet1"/></office:spreadsheet></office:body>
+</office:document-content>"#
+    }
+
+    fn unnamed_table_content_xml() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0">
+  <office:body><office:spreadsheet><table:table/></office:spreadsheet></office:body>
+</office:document-content>"#
+    }
 }

--- a/src/spreadsheet/reference.rs
+++ b/src/spreadsheet/reference.rs
@@ -1,3 +1,6 @@
+const MAX_COL_INDEX: usize = 16_383;
+const MAX_ROW_NUMBER: usize = 1_048_576;
+
 /// Converts a zero-based column index to Excel column letter notation
 ///
 /// Uses a precomputed lookup table for optimal performance. Supports
@@ -44,40 +47,12 @@ pub(crate) fn col_to_index(letters: &str) -> Option<usize> {
     let mut column = 0usize;
     for char in letters.chars() {
         if 'A' <= char && char <= 'Z' {
-            column = column * 26 + char as usize - 64;
+            column = column.checked_mul(26)?.checked_add(char as usize - 64)?;
         } else {
             break;
         }
     }
-    if column > 0 {
-        Some(column - 1)
-    } else {
-        None
-    }
-}
-
-/// Converts a zero-based row index to Excel row number string
-///
-/// Transforms internal zero-based row indexing into Excel's 1-based row numbering system.
-/// This conversion bridges the gap between internal storage (0-based) and Excel's
-/// user-facing representation (1-based).
-///
-/// The conversion is straightforward: adds 1 to the zero-based index and converts
-/// the result to a string. This maintains compatibility with Excel's row numbering
-/// convention while using efficient zero-based indexing internally.
-///
-/// # Arguments
-/// * `index` - Zero-based row index (0 = row 1, 1 = row 2, etc.)
-///
-/// # Returns
-/// Excel-style row number as a string (1-based)
-///
-/// # Examples
-/// - 0 -> "1"      // First row
-/// - 1 -> "2"      // Second row
-/// - 99 -> "100"   // 100th row
-pub(crate) fn index_to_row(index: usize) -> String {
-    (index + 1).to_string()
+    zero_based_column(column)
 }
 
 /// Converts an Excel row number string to a zero-based row index
@@ -89,22 +64,25 @@ pub(crate) fn index_to_row(index: usize) -> String {
 /// `Some(usize)` containing the zero-based row index if valid,
 /// `None` if the input cannot be parsed as a valid row number
 pub(crate) fn row_to_index(row: &str) -> Option<usize> {
-    row.parse::<usize>().ok().map(|row| row - 1)
+    row.parse::<usize>().ok().and_then(zero_based_row)
 }
 
-/// Converts zero-based row and column indices to an Excel-style cell reference
+/// Converts zero-based row and column indices to a cell reference
 ///
 /// # Arguments
 /// * `row_index` - Zero-based row index (0 = row 1)
 /// * `col_index` - Zero-based column index (0 = column "A")
 ///
 /// # Returns
-/// Excel-style cell reference as a string (e.g., "A1", "B2", "AB100")
+/// A1 notation for valid Excel coordinates, or R1C1 notation for out-of-range
+/// coordinates so malformed-file error reporting remains panic-free.
 pub(crate) fn index_to_reference(row_index: usize, col_index: usize) -> String {
-    let mut reference = String::new();
-    reference.push_str(index_to_col(col_index));
-    reference.push_str(&index_to_row(row_index));
-    reference
+    let row_number = row_index.saturating_add(1);
+    if let Some(column) = INDEXES_TO_COLUMNS.get(col_index) {
+        format!("{column}{row_number}")
+    } else {
+        format!("R{row_number}C{}", col_index.saturating_add(1))
+    }
 }
 
 /// Converts an Excel-style cell reference to zero-based row and column indices
@@ -135,17 +113,32 @@ pub(crate) fn index_to_reference(row_index: usize, col_index: usize) -> String {
 pub(crate) fn reference_to_index(letters: &str) -> Option<(usize, usize)> {
     let mut column = 0usize;
     let mut row = 0usize;
+    let mut row_started = false;
     for char in letters.chars() {
-        if 'A' <= char && char <= 'Z' {
-            column = column * 26 + char as usize - 64;
+        if 'A' <= char && char <= 'Z' && !row_started {
+            column = column.checked_mul(26)?.checked_add(char as usize - 64)?;
         } else if '0' <= char && char <= '9' {
-            row = row * 10 + char as usize - 48;
+            row_started = true;
+            row = row.checked_mul(10)?.checked_add(char as usize - 48)?;
         } else {
-            break;
+            return None;
         }
     }
-    if column > 0 {
-        Some((row - 1, column - 1))
+    Some((zero_based_row(row)?, zero_based_column(column)?))
+}
+
+fn zero_based_column(column: usize) -> Option<usize> {
+    let index = column.checked_sub(1)?;
+    if index <= MAX_COL_INDEX {
+        Some(index)
+    } else {
+        None
+    }
+}
+
+fn zero_based_row(row: usize) -> Option<usize> {
+    if (1..=MAX_ROW_NUMBER).contains(&row) {
+        Some(row - 1)
     } else {
         None
     }
@@ -1419,3 +1412,25 @@ const INDEXES_TO_COLUMNS: [&'static str; 16384] = [
     "XEF", "XEG", "XEH", "XEI", "XEJ", "XEK", "XEL", "XEM", "XEN", "XEO", "XEP", "XEQ", "XER",
     "XES", "XET", "XEU", "XEV", "XEW", "XEX", "XEY", "XEZ", "XFA", "XFB", "XFC", "XFD",
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_reference_bounds() {
+        assert_eq!(col_to_index("XFD"), Some(16_383));
+        assert_eq!(row_to_index("1048576"), Some(1_048_575));
+        assert_eq!(reference_to_index("XFD1048576"), Some((1_048_575, 16_383)));
+    }
+
+    #[test]
+    fn rejects_out_of_bounds_references() {
+        assert_eq!(col_to_index("XFE"), None);
+        assert_eq!(row_to_index("0"), None);
+        assert_eq!(row_to_index("1048577"), None);
+        assert_eq!(reference_to_index("A0"), None);
+        assert_eq!(reference_to_index("XFE1"), None);
+        assert_eq!(reference_to_index("A1048577"), None);
+    }
+}

--- a/src/spreadsheet/xls.rs
+++ b/src/spreadsheet/xls.rs
@@ -10,6 +10,7 @@ use crate::spreadsheet::cell::CellType;
 use crate::spreadsheet::criteria::Criteria;
 use crate::spreadsheet::excel::load_number_formats;
 use crate::spreadsheet::reference::index_to_reference;
+use crate::spreadsheet::resolve_number_format;
 use crate::spreadsheet::sheet::Sheet;
 use crate::spreadsheet::Spreadsheet;
 use crate::spreadsheet::SpreadsheetError;
@@ -201,7 +202,14 @@ impl Spreadsheet for XlsSpreadsheet {
                                 }
                                 last_row = Some(row);
                                 let index = self.reader.read_u16()? as usize;
-                                let kind = self.number_formats[index];
+                                let kind = resolve_number_format(
+                                    &self.number_formats,
+                                    &sheet.file_name,
+                                    &sheet.name,
+                                    row,
+                                    col,
+                                    index,
+                                )?;
                                 let value = self.reader.read_rk_number()?;
                                 sheet.push(Cell {
                                     row,
@@ -234,7 +242,14 @@ impl Spreadsheet for XlsSpreadsheet {
                             };
                             let kind = match either {
                                 Either::Left(kind) => kind,
-                                Either::Right(index) => self.number_formats[index],
+                                Either::Right(index) => resolve_number_format(
+                                    &self.number_formats,
+                                    &sheet.file_name,
+                                    &sheet.name,
+                                    row,
+                                    col,
+                                    index,
+                                )?,
                             };
                             if kind != CellType::Error {
                                 if !criteria.nulls.contains(&value) {

--- a/src/spreadsheet/xlsb.rs
+++ b/src/spreadsheet/xlsb.rs
@@ -10,6 +10,7 @@ use crate::spreadsheet::criteria::Criteria;
 use crate::spreadsheet::excel;
 use crate::spreadsheet::excel::load_relationships;
 use crate::spreadsheet::reference::index_to_reference;
+use crate::spreadsheet::resolve_number_format;
 use crate::spreadsheet::sheet::Sheet;
 use crate::spreadsheet::Spreadsheet;
 use crate::spreadsheet::SpreadsheetError;
@@ -221,7 +222,14 @@ impl Spreadsheet for XlsbSpreadsheet {
                             };
                             let kind = match either {
                                 Either::Left(kind) => kind,
-                                Either::Right(index) => (self.number_formats)[index],
+                                Either::Right(index) => resolve_number_format(
+                                    &self.number_formats,
+                                    &sheet.file_name,
+                                    &sheet.name,
+                                    row,
+                                    col,
+                                    index,
+                                )?,
                             };
                             if kind != CellType::Error {
                                 if !criteria.nulls.contains(&value) {

--- a/src/spreadsheet/xlsb.rs
+++ b/src/spreadsheet/xlsb.rs
@@ -135,7 +135,7 @@ impl Spreadsheet for XlsbSpreadsheet {
         };
 
         reader.find(BRT_BEGIN_SST)?;
-        for id in 0..reader.get_usize(4) {
+        for id in 0..reader.get_usize(4)? {
             reader.find_with(BRT_SST_ITEM, &[(BRT_FRT_BEGIN, BRT_FRT_END)])?;
             if let Some(keys) = &mut indexes {
                 if keys.contains(&id) {
@@ -190,7 +190,7 @@ impl Spreadsheet for XlsbSpreadsheet {
                 match tag {
                     BRT_END_SHEET_DATA => break,
                     BRT_ROW_HDR => {
-                        row = reader.get_usize(0);
+                        row = reader.get_usize(0)?;
                         if sheet.after_row_upper_bound(row) {
                             break;
                         }
@@ -203,7 +203,7 @@ impl Spreadsheet for XlsbSpreadsheet {
                     | BRT_CELL_ISST
                     | BRT_CELL_ERROR | BRT_FMLA_ERROR
                     if !sheet.before_row_lower_bound(row) => {
-                        let col = reader.get_usize(0);
+                        let col = reader.get_usize(0)?;
                         if sheet.contains(row, col) {
                             if let Some(last_row) = last_row {
                                 if criteria.end_at_empty_row && ((sheet.is_empty() && last_row != row) || (!sheet.is_empty() && last_row + 1 < row)) {
@@ -212,13 +212,13 @@ impl Spreadsheet for XlsbSpreadsheet {
                             }
                             last_row = Some(row);
                             let (either, value) = match tag {
-                                BRT_CELL_BOOL | BRT_FMLA_BOOL => read_bool_cell(&mut reader),
-                                BRT_CELL_REAL | BRT_FMLA_NUM => read_real_cell(&mut reader),
+                                BRT_CELL_BOOL | BRT_FMLA_BOOL => read_bool_cell(&mut reader)?,
+                                BRT_CELL_REAL | BRT_FMLA_NUM => read_real_cell(&mut reader)?,
                                 BRT_CELL_ST | BRT_FMLA_STRING => read_st_cell(&mut reader)?,
                                 BRT_CELL_R_STRING => read_rich_string_cell(&mut reader)?,
-                                BRT_CELL_ISST => read_shared_string_cell(&mut reader),
-                                BRT_CELL_ERROR | BRT_FMLA_ERROR => read_error_cell(&mut reader),
-                                _ => read_rk_cell(&mut reader),
+                                BRT_CELL_ISST => read_shared_string_cell(&mut reader)?,
+                                BRT_CELL_ERROR | BRT_FMLA_ERROR => read_error_cell(&mut reader)?,
+                                _ => read_rk_cell(&mut reader)?,
                             };
                             let kind = match either {
                                 Either::Left(kind) => kind,
@@ -290,7 +290,7 @@ fn load_workbook(zip: &mut ZipArchive<UnifiedReader>) -> Result<(Vec<(String, St
             }
         }
         BRT_WB_PROP => {
-            is_1904 = (&reader.buffer[0] & 0x1) != 0;
+            is_1904 = (reader.get_u8(0)? & 0x1) != 0;
         }
     });
     Ok((sheets, is_1904))
@@ -317,9 +317,9 @@ fn load_number_formats(zip: &mut ZipArchive<UnifiedReader>, is_1904: bool) -> Re
     let mut format_indexes: Vec<String> = Vec::new();
     match_biff12_record!(reader => {
         BRT_BEGIN_FMTS => {
-            for _ in 0..reader.get_usize(0) {
+            for _ in 0..reader.get_usize(0)? {
                 reader.find(BRT_FMT)?;
-                let id = reader.get_u16(0);
+                let id = reader.get_u16(0)?;
                 let format = reader.get_str(2)?;
                 custom_formats.insert(
                     id.to_string(),
@@ -328,9 +328,9 @@ fn load_number_formats(zip: &mut ZipArchive<UnifiedReader>, is_1904: bool) -> Re
             }
         }
         BRT_BEGIN_CELL_XFS => {
-            for _ in 0..reader.get_usize(0) {
+            for _ in 0..reader.get_usize(0)? {
                 reader.find(BRT_XF)?;
-                let id = reader.get_u16(2);
+                let id = reader.get_u16(2)?;
                 format_indexes.push(id.to_string());
             }
             break;
@@ -349,9 +349,11 @@ fn load_number_formats(zip: &mut ZipArchive<UnifiedReader>, is_1904: bool) -> Re
 /// * `(Either<CellType, usize>, String)` - Tuple containing:
 ///   - Cell type (boolean) and format index
 ///   - String representation of boolean value ("1" or "0")
-fn read_bool_cell(reader: &mut Biff12Reader<BufReader<ZipFile<UnifiedReader>>>) -> (Either<CellType, usize>, String) {
-    let value = if reader.buffer[8] != 0 { "1" } else { "0" };
-    (Either::Left(CellType::Boolean), value.to_owned())
+fn read_bool_cell(
+    reader: &mut Biff12Reader<BufReader<ZipFile<UnifiedReader>>>,
+) -> Result<(Either<CellType, usize>, String), RustySheetError> {
+    let value = if reader.get_u8(8)? != 0 { "1" } else { "0" };
+    Ok((Either::Left(CellType::Boolean), value.to_owned()))
 }
 
 /// Reads a real number (double precision) cell value from BIFF12 data
@@ -363,10 +365,12 @@ fn read_bool_cell(reader: &mut Biff12Reader<BufReader<ZipFile<UnifiedReader>>>) 
 /// * `(Either<CellType, usize>, String)` - Tuple containing:
 ///   - Format index reference and cell type
 ///   - String representation of numeric value
-fn read_real_cell(reader: &mut Biff12Reader<BufReader<ZipFile<UnifiedReader>>>) -> (Either<CellType, usize>, String) {
-    let index = reader.get_style(4);
-    let value = reader.get_f64(8).to_string();
-    (Either::Right(index), value)
+fn read_real_cell(
+    reader: &mut Biff12Reader<BufReader<ZipFile<UnifiedReader>>>,
+) -> Result<(Either<CellType, usize>, String), RustySheetError> {
+    let index = reader.get_style(4)?;
+    let value = reader.get_f64(8)?.to_string();
+    Ok((Either::Right(index), value))
 }
 
 /// Reads an inline string cell value from BIFF12 data
@@ -406,9 +410,11 @@ fn read_rich_string_cell(reader: &mut Biff12Reader<BufReader<ZipFile<UnifiedRead
 /// * `(Either<CellType, usize>, String)` - Tuple containing:
 ///   - Cell type (shared string) and format index
 ///   - String representation of shared string index
-fn read_shared_string_cell(reader: &mut Biff12Reader<BufReader<ZipFile<UnifiedReader>>>) -> (Either<CellType, usize>, String) {
-    let value = reader.get_usize(8).to_string();
-    (Either::Left(CellType::SharedString), value)
+fn read_shared_string_cell(
+    reader: &mut Biff12Reader<BufReader<ZipFile<UnifiedReader>>>,
+) -> Result<(Either<CellType, usize>, String), RustySheetError> {
+    let value = reader.get_usize(8)?.to_string();
+    Ok((Either::Left(CellType::SharedString), value))
 }
 
 /// Reads an error cell value from BIFF12 data
@@ -420,9 +426,11 @@ fn read_shared_string_cell(reader: &mut Biff12Reader<BufReader<ZipFile<UnifiedRe
 /// * `(Either<CellType, usize>, String)` - Tuple containing:
 ///   - Cell type (error) and format index
 ///   - String representation of error value
-fn read_error_cell(reader: &mut Biff12Reader<BufReader<ZipFile<UnifiedReader>>>) -> (Either<CellType, usize>, String) {
-    let value = to_error_value(reader.buffer[8]).to_owned();
-    (Either::Left(CellType::Error), value)
+fn read_error_cell(
+    reader: &mut Biff12Reader<BufReader<ZipFile<UnifiedReader>>>,
+) -> Result<(Either<CellType, usize>, String), RustySheetError> {
+    let value = to_error_value(reader.get_u8(8)?).to_owned();
+    Ok((Either::Left(CellType::Error), value))
 }
 
 /// Reads an RK (compressed floating point) cell value from BIFF12 data
@@ -437,16 +445,19 @@ fn read_error_cell(reader: &mut Biff12Reader<BufReader<ZipFile<UnifiedReader>>>)
 /// * `(Either<CellType, usize>, String)` - Tuple containing:
 ///   - Format index reference and cell type
 ///   - String representation of decompressed numeric value
-fn read_rk_cell(reader: &mut Biff12Reader<BufReader<ZipFile<UnifiedReader>>>) -> (Either<CellType, usize>, String) {
-    let index = reader.get_style(4);
-    let is_percentage = (reader.buffer[8] & 0x01) != 0;
-    let is_integer = (reader.buffer[8] & 0x02) != 0;
-    reader.buffer[8] &= 0xFC; // Clear A and B flag bits
+fn read_rk_cell(
+    reader: &mut Biff12Reader<BufReader<ZipFile<UnifiedReader>>>,
+) -> Result<(Either<CellType, usize>, String), RustySheetError> {
+    let index = reader.get_style(4)?;
+    let flags = reader.get_u8(8)?;
+    let is_percentage = (flags & 0x01) != 0;
+    let is_integer = (flags & 0x02) != 0;
+    reader.buffer[8] = flags & 0xFC; // Clear A and B flag bits
 
     let mut value = if is_integer {
-        (reader.get_i32(8) >> 2) as f64
+        (reader.get_i32(8)? >> 2) as f64
     } else {
-        let value = (reader.get_u32(8) >> 2) as u64;
+        let value = (reader.get_u32(8)? >> 2) as u64;
         f64::from_bits(value << 34)
     };
     if is_percentage {
@@ -458,5 +469,5 @@ fn read_rk_cell(reader: &mut Biff12Reader<BufReader<ZipFile<UnifiedReader>>>) ->
         value.to_string()
     };
 
-    (Either::Right(index), value)
- }
+    Ok((Either::Right(index), value))
+}

--- a/src/spreadsheet/xlsx.rs
+++ b/src/spreadsheet/xlsx.rs
@@ -544,21 +544,11 @@ mod tests {
 
     #[test]
     fn invalid_style_index_returns_error() {
-        let path = invalid_style_workbook_path();
+        let path = invalid_workbook_path("style");
         write_invalid_style_workbook(&path);
 
         let mut spreadsheet = XlsxSpreadsheet::open(path.to_str().unwrap()).unwrap();
-        let result = spreadsheet.read_sheets(&Criteria {
-            sheet_name_patterns: None,
-            sheet_limit: None,
-            range: None,
-            rows_limit: None,
-            nulls: HashSet::from(["".to_string()]),
-            error_as_null: false,
-            skip_empty_rows: false,
-            end_at_empty_row: false,
-            spread_merged_cells: false,
-        });
+        let result = spreadsheet.read_sheets(&default_criteria());
 
         std::fs::remove_file(path).unwrap();
         let error = match result {
@@ -570,18 +560,50 @@ mod tests {
         assert!(error.contains("workbook defines 1 styles"));
     }
 
-    fn invalid_style_workbook_path() -> PathBuf {
+    #[test]
+    fn invalid_shared_string_index_returns_error() {
+        let path = invalid_workbook_path("shared-string");
+        write_invalid_shared_string_workbook(&path);
+
+        let mut spreadsheet = XlsxSpreadsheet::open(path.to_str().unwrap()).unwrap();
+        let result = spreadsheet.analyze_sheets(true, &default_criteria(), &Vec::new());
+
+        std::fs::remove_file(path).unwrap();
+        let error = match result {
+            Ok(_) => panic!("expected invalid shared string index error"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("Sheet1!A1"));
+        assert!(error.contains("invalid shared string index 999"));
+    }
+
+    fn invalid_workbook_path(kind: &str) -> PathBuf {
         let id = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        std::env::temp_dir().join(format!("rusty-sheet-invalid-style-{id}.xlsx"))
+        std::env::temp_dir().join(format!("rusty-sheet-invalid-{kind}-{id}.xlsx"))
+    }
+
+    fn default_criteria() -> Criteria {
+        Criteria {
+            sheet_name_patterns: None,
+            sheet_limit: None,
+            range: None,
+            rows_limit: None,
+            nulls: HashSet::from(["".to_string()]),
+            error_as_null: false,
+            skip_empty_rows: false,
+            end_at_empty_row: false,
+            spread_merged_cells: false,
+        }
     }
 
     fn write_invalid_style_workbook(path: &Path) {
         let file = File::create(path).unwrap();
         let mut zip = ZipWriter::new(file);
-        let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
         let rows = (2..11)
             .map(|row| format!("<row r=\"{row}\"><c r=\"A{row}\"><v>{row}</v></c></row>"))
             .collect::<String>();
@@ -634,6 +656,67 @@ mod tests {
 </styleSheet>"#.to_string(),
             ),
             ("xl/worksheets/sheet1.xml", sheet),
+        ] {
+            zip.start_file(name, options).unwrap();
+            zip.write_all(content.as_bytes()).unwrap();
+        }
+        zip.finish().unwrap();
+    }
+
+    fn write_invalid_shared_string_workbook(path: &Path) {
+        let file = File::create(path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+        for (name, content) in [
+            (
+                "[Content_Types].xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
+</Types>"#.to_string(),
+            ),
+            (
+                "_rels/.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"#.to_string(),
+            ),
+            (
+                "xl/workbook.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+</workbook>"#.to_string(),
+            ),
+            (
+                "xl/_rels/workbook.xml.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>
+</Relationships>"#.to_string(),
+            ),
+            (
+                "xl/sharedStrings.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="1" uniqueCount="1">
+  <si><t>name</t></si>
+</sst>"#.to_string(),
+            ),
+            (
+                "xl/worksheets/sheet1.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData><row r="1"><c r="A1" t="s"><v>999</v></c></row></sheetData>
+</worksheet>"#.to_string(),
+            ),
         ] {
             zip.start_file(name, options).unwrap();
             zip.write_all(content.as_bytes()).unwrap();

--- a/src/spreadsheet/xlsx.rs
+++ b/src/spreadsheet/xlsx.rs
@@ -208,9 +208,17 @@ impl Spreadsheet for XlsxSpreadsheet {
                     col_count = 0;
                 }
                 Event::Start(event) if event.name() == TAG_CELL => {
-                    (row, col) = event.get_attribute_value("r")?
-                        .and_then(|reference| reference_to_index(&reference))
-                        .unwrap_or((row_count, col_count));
+                    if let Some(reference) = event.get_attribute_value("r")? {
+                        (row, col) = reference_to_index(&reference).ok_or_else(|| {
+                            SpreadsheetError::CellReferenceError(
+                                sheet.file_name.to_owned(),
+                                sheet.name.to_owned(),
+                                reference.to_string(),
+                            )
+                        })?;
+                    } else {
+                        (row, col) = (row_count, col_count);
+                    }
                     col_count += 1;
                     if sheet.after_row_upper_bound(row) {
                         break;
@@ -577,6 +585,23 @@ mod tests {
         assert!(error.contains("invalid shared string index 999"));
     }
 
+    #[test]
+    fn invalid_cell_reference_returns_error() {
+        let path = invalid_workbook_path("cell-reference");
+        write_invalid_cell_reference_workbook(&path);
+
+        let mut spreadsheet = XlsxSpreadsheet::open(path.to_str().unwrap()).unwrap();
+        let result = spreadsheet.read_sheets(&default_criteria());
+
+        std::fs::remove_file(path).unwrap();
+        let error = match result {
+            Ok(_) => panic!("expected invalid cell reference error"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("Sheet1"));
+        assert!(error.contains("invalid cell reference 'XFE1'"));
+    }
+
     fn invalid_workbook_path(kind: &str) -> PathBuf {
         let id = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -715,6 +740,58 @@ mod tests {
                 r#"<?xml version="1.0" encoding="UTF-8"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
   <sheetData><row r="1"><c r="A1" t="s"><v>999</v></c></row></sheetData>
+</worksheet>"#.to_string(),
+            ),
+        ] {
+            zip.start_file(name, options).unwrap();
+            zip.write_all(content.as_bytes()).unwrap();
+        }
+        zip.finish().unwrap();
+    }
+
+    fn write_invalid_cell_reference_workbook(path: &Path) {
+        let file = File::create(path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+        for (name, content) in [
+            (
+                "[Content_Types].xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>"#.to_string(),
+            ),
+            (
+                "_rels/.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"#.to_string(),
+            ),
+            (
+                "xl/workbook.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+</workbook>"#.to_string(),
+            ),
+            (
+                "xl/_rels/workbook.xml.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"#.to_string(),
+            ),
+            (
+                "xl/worksheets/sheet1.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData><row r="1"><c r="XFE1" t="inlineStr"><is><t>value</t></is></c></row></sheetData>
 </worksheet>"#.to_string(),
             ),
         ] {

--- a/src/spreadsheet/xlsx.rs
+++ b/src/spreadsheet/xlsx.rs
@@ -602,6 +602,23 @@ mod tests {
         assert!(error.contains("invalid cell reference 'XFE1'"));
     }
 
+    #[test]
+    fn invalid_date_header_value_returns_error() {
+        let path = invalid_workbook_path("date-header");
+        write_invalid_date_header_workbook(&path);
+
+        let mut spreadsheet = XlsxSpreadsheet::open(path.to_str().unwrap()).unwrap();
+        let result = spreadsheet.analyze_sheets(true, &default_criteria(), &Vec::new());
+
+        std::fs::remove_file(path).unwrap();
+        let error = match result {
+            Ok(_) => panic!("expected invalid date header value error"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("Sheet1!A1"));
+        assert!(error.contains("parse 'not-a-number' to Date(1900) failed"));
+    }
+
     fn invalid_workbook_path(kind: &str) -> PathBuf {
         let id = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -792,6 +809,67 @@ mod tests {
                 r#"<?xml version="1.0" encoding="UTF-8"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
   <sheetData><row r="1"><c r="XFE1" t="inlineStr"><is><t>value</t></is></c></row></sheetData>
+</worksheet>"#.to_string(),
+            ),
+        ] {
+            zip.start_file(name, options).unwrap();
+            zip.write_all(content.as_bytes()).unwrap();
+        }
+        zip.finish().unwrap();
+    }
+
+    fn write_invalid_date_header_workbook(path: &Path) {
+        let file = File::create(path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+        for (name, content) in [
+            (
+                "[Content_Types].xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+</Types>"#.to_string(),
+            ),
+            (
+                "_rels/.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"#.to_string(),
+            ),
+            (
+                "xl/workbook.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+</workbook>"#.to_string(),
+            ),
+            (
+                "xl/_rels/workbook.xml.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+</Relationships>"#.to_string(),
+            ),
+            (
+                "xl/styles.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <cellXfs count="1"><xf numFmtId="14"/></cellXfs>
+</styleSheet>"#.to_string(),
+            ),
+            (
+                "xl/worksheets/sheet1.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData><row r="1"><c r="A1" s="0"><v>not-a-number</v></c></row></sheetData>
 </worksheet>"#.to_string(),
             ),
         ] {

--- a/src/spreadsheet/xlsx.rs
+++ b/src/spreadsheet/xlsx.rs
@@ -172,7 +172,7 @@ impl Spreadsheet for XlsxSpreadsheet {
             };
 
             // Single pass: Read cells and collect merged cell ranges
-            let mut reader = self.zip.xml_reader(zip_path)?.expect(sheet_name);
+            let mut reader = required_xml_reader(&mut self.zip, zip_path)?;
             let mut in_merge_cells = false;
             
             match_xml_events!(reader => {
@@ -383,8 +383,7 @@ impl Spreadsheet for XlsxSpreadsheet {
 /// Tuple of (worksheets, is_1904_date_system) where worksheets are (name, zip_path) pairs
 fn load_workbook(zip: &mut ZipArchive<UnifiedReader>) -> Result<(Vec<(String, String)>, bool), RustySheetError> {
     let relationships = load_relationships(zip, "xl/_rels/workbook.xml.rels")?;
-    let mut reader = zip.xml_reader("xl/workbook.xml")?
-        .ok_or_else(|| SpreadsheetError::FileError("xl/workbook.xml".to_string()))?;
+    let mut reader = required_xml_reader(zip, "xl/workbook.xml")?;
     let mut sheets: Vec<(String, String)> = Vec::new();
     let mut is_1904 = false;
     match_xml_events!(reader => {
@@ -503,6 +502,15 @@ fn parse_merge_range(range_ref: &str) -> Option<(usize, usize, usize, usize)> {
     Some((top_row, top_col, bottom_row, bottom_col))
 }
 
+fn required_xml_reader<'a>(
+    zip: &'a mut ZipArchive<UnifiedReader>,
+    path: &str,
+) -> Result<XmlReader<BufReader<ZipFile<'a, UnifiedReader>>>, RustySheetError> {
+    zip.xml_reader(path)?.ok_or_else(|| {
+        RustySheetError::from(SpreadsheetError::FileError(path.to_string()))
+    })
+}
+
 /// Reads string value from XML content, handling text and CDATA sections
 ///
 /// Extracts string content from XML elements, skipping phonetic text annotations
@@ -617,6 +625,23 @@ mod tests {
         };
         assert!(error.contains("Sheet1!A1"));
         assert!(error.contains("parse 'not-a-number' to Date(1900) failed"));
+    }
+
+    #[test]
+    fn missing_sheet_xml_returns_error() {
+        let path = invalid_workbook_path("missing-sheet");
+        write_missing_sheet_workbook(&path);
+
+        let mut spreadsheet = XlsxSpreadsheet::open(path.to_str().unwrap()).unwrap();
+        let result = spreadsheet.read_sheets(&default_criteria());
+
+        std::fs::remove_file(path).unwrap();
+        let error = match result {
+            Ok(_) => panic!("expected missing sheet XML error"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("xl/worksheets/sheet1.xml"));
+        assert!(error.contains("missing or corrupted"));
     }
 
     fn invalid_workbook_path(kind: &str) -> PathBuf {
@@ -871,6 +896,51 @@ mod tests {
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
   <sheetData><row r="1"><c r="A1" s="0"><v>not-a-number</v></c></row></sheetData>
 </worksheet>"#.to_string(),
+            ),
+        ] {
+            zip.start_file(name, options).unwrap();
+            zip.write_all(content.as_bytes()).unwrap();
+        }
+        zip.finish().unwrap();
+    }
+
+    fn write_missing_sheet_workbook(path: &Path) {
+        let file = File::create(path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+        for (name, content) in [
+            (
+                "[Content_Types].xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>"#.to_string(),
+            ),
+            (
+                "_rels/.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"#.to_string(),
+            ),
+            (
+                "xl/workbook.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+</workbook>"#.to_string(),
+            ),
+            (
+                "xl/_rels/workbook.xml.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"#.to_string(),
             ),
         ] {
             zip.start_file(name, options).unwrap();

--- a/src/spreadsheet/xlsx.rs
+++ b/src/spreadsheet/xlsx.rs
@@ -15,6 +15,7 @@ use crate::spreadsheet::excel;
 use crate::spreadsheet::excel::load_relationships;
 use crate::spreadsheet::reference::index_to_reference;
 use crate::spreadsheet::reference::reference_to_index;
+use crate::spreadsheet::resolve_number_format;
 use crate::spreadsheet::sheet::Sheet;
 use quick_xml::events::Event;
 use quick_xml::name::QName;
@@ -231,7 +232,14 @@ impl Spreadsheet for XlsxSpreadsheet {
                         if let Some(format_id) = event.get_attribute_value("s")? {
                             if kind == CellType::Number && !format_id.is_empty() {
                                 let index = format_id.parse::<usize>()?;
-                                kind = self.number_formats[index];
+                                kind = resolve_number_format(
+                                    &self.number_formats,
+                                    &sheet.file_name,
+                                    &sheet.name,
+                                    row,
+                                    col,
+                                    index,
+                                )?;
                             }
                         }
                     } else {
@@ -518,4 +526,118 @@ fn read_string_value(
         Event::GeneralRef(event) if is_text => text.push_bytes_ref(&event)?,
     });
     Ok(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spreadsheet::criteria::Criteria;
+    use std::collections::HashSet;
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::Path;
+    use std::path::PathBuf;
+    use std::time::SystemTime;
+    use std::time::UNIX_EPOCH;
+    use zip::write::SimpleFileOptions;
+    use zip::ZipWriter;
+
+    #[test]
+    fn invalid_style_index_returns_error() {
+        let path = invalid_style_workbook_path();
+        write_invalid_style_workbook(&path);
+
+        let mut spreadsheet = XlsxSpreadsheet::open(path.to_str().unwrap()).unwrap();
+        let result = spreadsheet.read_sheets(&Criteria {
+            sheet_name_patterns: None,
+            sheet_limit: None,
+            range: None,
+            rows_limit: None,
+            nulls: HashSet::from(["".to_string()]),
+            error_as_null: false,
+            skip_empty_rows: false,
+            end_at_empty_row: false,
+            spread_merged_cells: false,
+        });
+
+        std::fs::remove_file(path).unwrap();
+        let error = match result {
+            Ok(_) => panic!("expected invalid style index error"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("Sheet1!A11"));
+        assert!(error.contains("invalid style index 999"));
+        assert!(error.contains("workbook defines 1 styles"));
+    }
+
+    fn invalid_style_workbook_path() -> PathBuf {
+        let id = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("rusty-sheet-invalid-style-{id}.xlsx"))
+    }
+
+    fn write_invalid_style_workbook(path: &Path) {
+        let file = File::create(path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        let rows = (2..11)
+            .map(|row| format!("<row r=\"{row}\"><c r=\"A{row}\"><v>{row}</v></c></row>"))
+            .collect::<String>();
+        let sheet = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>value</t></is></c></row>{rows}<row r="11"><c r="A11" s="999"><v>11</v></c></row></sheetData>
+</worksheet>"#
+        );
+
+        for (name, content) in [
+            (
+                "[Content_Types].xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+</Types>"#.to_string(),
+            ),
+            (
+                "_rels/.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"#.to_string(),
+            ),
+            (
+                "xl/workbook.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+</workbook>"#.to_string(),
+            ),
+            (
+                "xl/_rels/workbook.xml.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+</Relationships>"#.to_string(),
+            ),
+            (
+                "xl/styles.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <cellXfs count="1"><xf numFmtId="0"/></cellXfs>
+</styleSheet>"#.to_string(),
+            ),
+            ("xl/worksheets/sheet1.xml", sheet),
+        ] {
+            zip.start_file(name, options).unwrap();
+            zip.write_all(content.as_bytes()).unwrap();
+        }
+        zip.finish().unwrap();
+    }
 }


### PR DESCRIPTION
Codex:
> Stack order: this PR is intended to follow PR [#27](https://github.com/redraiment/rusty-sheet/pull/27), and PR [#22](https://github.com/redraiment/rusty-sheet/pull/22) should follow this PR. GitHub cannot base this fork PR on fork-only branches, so it is temporarily opened against `main`.
>
> Malformed ZIP-based spreadsheets can omit XML members that the workbook metadata points at, or omit required ODS table names. The XLSX and ODS readers previously used `expect(...)` in those paths, so malformed files could panic instead of returning a spreadsheet error.
>
> Changes:
> - add required XML member helpers for XLSX and ODS readers;
> - return the existing missing/corrupted file error for absent required XML parts;
> - return a normal malformed-file error for ODS table elements without `table:name`;
> - add XLSX and ODS malformed archive regressions.
>
> Verification:
> - `cargo test --locked --lib` (21 tests): passed.
> - `git diff --check`: passed.
